### PR TITLE
feat: move AI credits into navbar + persist Study Companion chats

### DIFF
--- a/src/app/study-companion/[quizId]/chat/page.tsx
+++ b/src/app/study-companion/[quizId]/chat/page.tsx
@@ -1,18 +1,14 @@
 "use client";
 
 import Link from "next/link";
-import { ArrowLeft, Send, Sparkles } from "lucide-react";
+import { ArrowLeft, Send, Sparkles, Trash2 } from "lucide-react";
 import { use, useEffect, useMemo, useRef, useState } from "react";
 import { useQuizById } from "@/lib/quiz-data";
 import { modelTier } from "@/lib/ai/openrouter";
 import ModelPicker, { DEFAULT_MODEL_ID } from "@/components/ui/model-picker";
 import { useStore } from "@/store/use-store";
-
-type Message = {
-  id: string;
-  role: "user" | "assistant";
-  content: string;
-};
+import { useAiAnalyze } from "@/lib/use-ai-analyze";
+import type { ChatMessage as Message } from "@/store/use-store";
 
 // Inline-format a single line: **bold**, *italic*, _italic_, `code`.
 function renderInline(text: string, keyBase: string): React.ReactNode[] {
@@ -125,6 +121,11 @@ export default function StudyCompanionChat({
   const { quizId } = use(params);
   const liveQuiz = useQuizById(quizId);
   const attempts = useStore((s) => s.attempts);
+  const setChatSession = useStore((s) => s.setChatSession);
+  const clearChatSession = useStore((s) => s.clearChatSession);
+  // Refreshes the shared free/premium counters (shown in the navbar) after a
+  // premium reply spends a credit.
+  const { refresh: refreshUsage } = useAiAnalyze();
 
   // Latest attempt for this quiz (so the AI sees what the user actually answered).
   const attempt = useMemo(() => {
@@ -182,6 +183,32 @@ export default function StudyCompanionChat({
   const [messages, setMessages] = useState<Message[]>([
     { id: "welcome", role: "assistant", content: welcomeContent },
   ]);
+  const [streaming, setStreaming] = useState(false);
+  const [chatModel, setChatModel] = useState(DEFAULT_MODEL_ID);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  // Gate persistence until we've loaded any saved transcript, so the initial
+  // welcome-only render can't overwrite a stored conversation.
+  const hydratedRef = useRef(false);
+
+  // Hydrate the saved transcript once (client-only, to avoid an SSR mismatch).
+  useEffect(() => {
+    if (hydratedRef.current) return;
+    const stored = useStore.getState().chatSessions[quizId];
+    if (stored && stored.length > 0) {
+      setMessages(stored);
+    }
+    hydratedRef.current = true;
+  }, [quizId]);
+
+  // Persist the transcript whenever it settles (not mid-stream). A chat that's
+  // only the welcome message isn't worth saving — clearing it removes the
+  // stored entry entirely so a deleted chat stays deleted.
+  useEffect(() => {
+    if (!hydratedRef.current || streaming) return;
+    const hasConversation = messages.some((m) => m.id !== "welcome");
+    if (hasConversation) setChatSession(quizId, messages);
+    else clearChatSession(quizId);
+  }, [messages, streaming, quizId, setChatSession, clearChatSession]);
 
   // If the attempt loads after first render (e.g. from persisted store), refresh
   // the welcome message so the AI's opener reflects the real score.
@@ -192,13 +219,22 @@ export default function StudyCompanionChat({
       return [{ ...prev[0], content: welcomeContent }, ...prev.slice(1)];
     });
   }, [welcomeContent]);
-  const [streaming, setStreaming] = useState(false);
-  const [chatModel, setChatModel] = useState(DEFAULT_MODEL_ID);
-  const scrollRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     scrollRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages]);
+
+  const handleClearChat = () => {
+    if (
+      typeof window !== "undefined" &&
+      messages.some((m) => m.id !== "welcome") &&
+      !window.confirm("Delete this chat? This can't be undone.")
+    ) {
+      return;
+    }
+    clearChatSession(quizId);
+    setMessages([{ id: "welcome", role: "assistant", content: welcomeContent }]);
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -317,6 +353,9 @@ export default function StudyCompanionChat({
       );
     } finally {
       setStreaming(false);
+      // A premium reply just spent a credit server-side; pull the fresh
+      // balance so the navbar counter updates without a page reload.
+      if (modelTier(chatModel) === "premium") refreshUsage();
     }
   };
 
@@ -330,10 +369,21 @@ export default function StudyCompanionChat({
           <ArrowLeft size={18} />
           <span className="text-sm">Back to Study Companion</span>
         </Link>
-        <span className="self-start sm:self-auto flex items-center gap-1 px-3 py-1 bg-indigo-50 text-indigo-primary text-xs font-medium rounded-full">
-          <Sparkles size={12} />
-          Powered by AI
-        </span>
+        <div className="flex items-center gap-2 self-start sm:self-auto">
+          <button
+            type="button"
+            onClick={handleClearChat}
+            disabled={streaming}
+            className="flex items-center gap-1.5 rounded-full border border-gray-200 px-3 py-1 text-xs font-medium text-gray-primary transition hover:border-red-200 hover:bg-red-50 hover:text-red-600 disabled:opacity-50"
+          >
+            <Trash2 size={12} />
+            Delete chat
+          </button>
+          <span className="flex items-center gap-1 px-3 py-1 bg-indigo-50 text-indigo-primary text-xs font-medium rounded-full">
+            <Sparkles size={12} />
+            Powered by AI
+          </span>
+        </div>
       </div>
 
       <div className="mb-8">

--- a/src/app/study-companion/page.tsx
+++ b/src/app/study-companion/page.tsx
@@ -1,13 +1,12 @@
 "use client";
 
 import Link from "next/link";
-import { Suspense, useEffect, useState } from "react";
+import { Suspense, useEffect } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
-import { FileText, MessagesSquare, Sparkles, Zap } from "lucide-react";
+import { FileText, MessagesSquare, Sparkles } from "lucide-react";
 import toast from "react-hot-toast";
 import { useStore } from "@/store/use-store";
 import { useAiUsageOnMount } from "@/lib/use-ai-analyze";
-import BuyCreditsModal from "@/components/ui/buy-credits-modal";
 
 export default function StudyCompanion() {
   return (
@@ -21,8 +20,9 @@ function StudyCompanionInner() {
   const attempts = useStore((s) => s.attempts);
   const liveQuizzes = useStore((s) => s.quizzes);
   const coursesCache = useStore((s) => s.coursesCache);
-  const { remaining, credits, refresh } = useAiUsageOnMount();
-  const [buyOpen, setBuyOpen] = useState(false);
+  // Credits are shown in the navbar now; we still refresh here to catch the
+  // balance update after returning from a successful purchase.
+  const { refresh } = useAiUsageOnMount();
   const searchParams = useSearchParams();
   const router = useRouter();
 
@@ -112,37 +112,13 @@ function StudyCompanionInner() {
   return (
     <div className="min-h-dvh bg-white px-4 sm:px-6 md:px-10 lg:px-14.75 py-6 md:py-11.5">
       {/* Header */}
-      <div className="mb-8 flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-        <div>
-          <h1 className="text-[28px] font-semibold text-black-primary mb-2">
-            Study Companion
-          </h1>
-          <p className="text-gray-primary">
-            AI that reviews your answers, explains mistakes, and helps you improve.
-          </p>
-        </div>
-
-        {/* Usage + buy credits */}
-        <div
-          data-tour="ai-credits"
-          className="flex flex-wrap items-center gap-2"
-        >
-          <span className="rounded-full bg-gray-100 px-3 py-1.5 text-xs font-medium text-gray-700">
-            {remaining ?? "…"} free today
-          </span>
-          <span className="flex items-center gap-1 rounded-full bg-indigo-50 px-3 py-1.5 text-xs font-medium text-indigo-primary">
-            <Zap size={12} />
-            {credits ?? "…"} premium credits
-          </span>
-          <button
-            type="button"
-            data-tour="buy-credits"
-            onClick={() => setBuyOpen(true)}
-            className="rounded-lg bg-indigo-primary px-3 py-1.5 text-xs font-medium text-white transition hover:bg-indigo-600"
-          >
-            Buy credits
-          </button>
-        </div>
+      <div className="mb-8">
+        <h1 className="text-[28px] font-semibold text-black-primary mb-2">
+          Study Companion
+        </h1>
+        <p className="text-gray-primary">
+          AI that reviews your answers, explains mistakes, and helps you improve.
+        </p>
       </div>
 
       {/* Course Readiness — pass/at-risk based on quiz performance */}
@@ -280,8 +256,6 @@ function StudyCompanionInner() {
           </div>
         )}
       </div>
-
-      <BuyCreditsModal isOpen={buyOpen} onClose={() => setBuyOpen(false)} />
     </div>
   );
 }

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -21,9 +21,12 @@ import {
   HelpCircle,
   Menu,
   Bell,
+  Zap,
 } from "lucide-react";
 import { useCurrentUser } from "@/lib/use-current-user";
 import { useStore } from "@/store/use-store";
+import { useAiUsageOnMount } from "@/lib/use-ai-analyze";
+import BuyCreditsModal from "@/components/ui/buy-credits-modal";
 import { parseTaskDate, toLocalIsoDate } from "@/lib/task-date";
 import toast from "react-hot-toast";
 
@@ -121,6 +124,12 @@ function saveReminderHistory(map: Record<string, number>) {
 const Navbar: React.FC<NavbarProps> = ({ className = "", onToggleSidebar }) => {
   const router = useRouter();
   const { user } = useCurrentUser();
+
+  /* ---------- AI usage (free + premium credits) ---------- */
+  // Lives in the navbar so the counters sit beside the search bar and bell on
+  // every page, and stay in sync from one global store pool.
+  const { remaining, credits } = useAiUsageOnMount();
+  const [buyOpen, setBuyOpen] = useState(false);
 
   /* ---------- profile state ---------- */
   const [profile, setProfile] = useState<Profile | null>(null);
@@ -631,8 +640,30 @@ const Navbar: React.FC<NavbarProps> = ({ className = "", onToggleSidebar }) => {
         )}
       </div>
 
+      {/* ---- AI usage + buy credits ---- */}
+      <div
+        data-tour="ai-credits"
+        className="ml-auto hidden items-center gap-2 sm:flex shrink-0"
+      >
+        <span className="hidden rounded-full bg-gray-100 px-3 py-1.5 text-xs font-medium text-gray-700 lg:inline-flex">
+          {remaining ?? "…"} free today
+        </span>
+        <span className="flex items-center gap-1 rounded-full bg-indigo-50 px-3 py-1.5 text-xs font-medium text-indigo-primary">
+          <Zap size={12} />
+          {credits ?? "…"} premium credits
+        </span>
+        <button
+          type="button"
+          data-tour="buy-credits"
+          onClick={() => setBuyOpen(true)}
+          className="rounded-lg bg-indigo-primary px-3 py-1.5 text-xs font-medium text-white transition hover:bg-indigo-600"
+        >
+          Buy credits
+        </button>
+      </div>
+
       {/* ---- Profile section ---- */}
-      <div ref={profileRef} className="relative ml-auto flex items-center gap-2 sm:gap-3 shrink-0">
+      <div ref={profileRef} className="relative flex items-center gap-2 sm:gap-3 shrink-0">
         <div ref={notificationsRef} className="relative">
           <button
             type="button"
@@ -849,6 +880,8 @@ const Navbar: React.FC<NavbarProps> = ({ className = "", onToggleSidebar }) => {
           </div>
         )}
       </div>
+
+      <BuyCreditsModal isOpen={buyOpen} onClose={() => setBuyOpen(false)} />
     </nav>
   );
 };

--- a/src/store/use-store.ts
+++ b/src/store/use-store.ts
@@ -118,6 +118,14 @@ export type QuizAttempt = {
   completedAt: string;
 };
 
+// A single Study Companion chat message. Persisted per quiz so the
+// conversation survives refreshes and navigation.
+export type ChatMessage = {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+};
+
 interface AppState {
   decks: FlashcardDeck[];
   setDecks: (d: FlashcardDeck[]) => void;
@@ -186,6 +194,13 @@ interface AppState {
     },
   ) => string;
   removeAttempt: (id: string) => void;
+
+  // Study Companion chat transcripts, keyed by quizId. Persisted so a chat
+  // survives a refresh; only removed when the user clears it (or the quiz it
+  // belongs to is deleted).
+  chatSessions: Record<string, ChatMessage[]>;
+  setChatSession: (quizId: string, messages: ChatMessage[]) => void;
+  clearChatSession: (quizId: string) => void;
 
   notificationEnabled: boolean;
   setNotificationEnabled: (enabled: boolean) => void;
@@ -392,6 +407,18 @@ export const useStore = create<AppState>()(
         removeAttempt: (id) => {
           set((state) => ({ attempts: state.attempts.filter((a) => a.id !== id) }));
         },
+        chatSessions: {},
+        setChatSession: (quizId, messages) =>
+          set((state) => ({
+            chatSessions: { ...state.chatSessions, [quizId]: messages },
+          })),
+        clearChatSession: (quizId) =>
+          set((state) => {
+            if (!(quizId in state.chatSessions)) return {};
+            const next = { ...state.chatSessions };
+            delete next[quizId];
+            return { chatSessions: next };
+          }),
         setDecks: (d) => set({ decks: d }),
         addTask: async (task) => {
           const id = task.id ?? uid('task')
@@ -427,10 +454,15 @@ export const useStore = create<AppState>()(
           // Companion entry disappears automatically. Study Companion is
           // strictly a live mirror of "quizzes you can still take", once
           // the quiz is gone, the review/chat for it should be gone too.
-          set((state) => ({
-            quizzes: state.quizzes.filter((q) => q.id !== id),
-            attempts: state.attempts.filter((a) => a.quizId !== id),
-          }))
+          set((state) => {
+            const nextChats = { ...state.chatSessions };
+            delete nextChats[id];
+            return {
+              quizzes: state.quizzes.filter((q) => q.id !== id),
+              attempts: state.attempts.filter((a) => a.quizId !== id),
+              chatSessions: nextChats,
+            };
+          })
         },
         setTasks: (tasks) => set({ tasks }),
         plannerEvents: [],


### PR DESCRIPTION
## What changed

**1. AI credits moved into the global navbar**
- The `free today` / `premium credits` pills and the **Buy credits** button now live in the navbar, right-aligned beside the search bar and notification bell, so they appear on every page (not just Study Companion).
- Removed the duplicate block from the Study Companion page header.
- Responsive: hidden on very small screens; premium pill + Buy button from `sm`, the `free today` pill from `lg`. The `data-tour` hooks moved with it so the onboarding tour still works.

**2. Premium credits now update after a chat reply**
- The Study Companion chat endpoint streams its response and spends a premium credit, but never told the client the new balance — so the counter stayed stale until a reload.
- After a premium reply finishes streaming, the chat page now refetches the balance into the shared store, which the navbar reads. The counter updates immediately.

**3. Study Companion chats persist + have history + manual delete**
- Chat transcripts are now saved **per quiz** in the persisted store (`chatSessions`), so a conversation survives refresh and navigation.
- The transcript hydrates on load; only the welcome message isn't saved (an untouched chat stays empty).
- A **Delete chat** button (with confirm) clears the conversation and removes it from storage. Deleting the underlying quiz also cascades and removes its chat session.

## Why
Credits were easy to miss tucked inside one page, and the premium balance appeared "stuck" because the streaming chat path never refreshed it client-side. Chats were lost on every refresh since they were component-local state only.

## Reviewer notes
- New store fields: `chatSessions`, `setChatSession`, `clearChatSession`; `removeQuiz` cascades to clear the chat. No persist version bump needed — the new field merges in as `{}` for existing localStorage state.
- Typecheck (`tsc --noEmit`) and ESLint pass on the changed files.
