### PR TITLE
feat: remove output token cap on quiz/flashcard generation

### DIFF
--- a/src/app/api/ai/flashcards/generate/route.ts
+++ b/src/app/api/ai/flashcards/generate/route.ts
@@ -228,15 +228,16 @@ export async function POST(req: NextRequest) {
         return `\n\nDo NOT repeat or rephrase any of these already-created card fronts:\n${recent}`;
       };
 
-      // `want` sizes the output token cap so the JSON array for that many
-      // cards isn't truncated (~130 tokens per card + overhead).
+      // No output token cap (`maxTokens: 0`) — the model returns as many
+      // tokens as it wants, so the JSON array is never truncated mid-way
+      // regardless of how many cards it produces. Runtime is still bounded by
+      // the per-call `deadlineMs` and the route's maxDuration.
       const runCall = async (
         messages: Parameters<typeof chatWithFallback>[0],
-        want: number,
       ): Promise<{ front: string; back: string }[]> => {
         const resp = await chatWithFallback(messages, chain, {
           deadlineMs: remainingBudget(),
-          maxTokens: 400 + want * 140,
+          maxTokens: 0,
         });
         const parsed = normalizeOpenRouterFlashcards(resp.content);
         if (!parsed || !parsed.cards?.length) return [];
@@ -271,19 +272,16 @@ export async function POST(req: NextRequest) {
               `because it is handwritten.` + avoidClause();
             try {
               pushUnique(
-                await runCall(
-                  [
-                    { role: "system", content: system },
-                    {
-                      role: "user",
-                      content: [
-                        { type: "text", text: userInstruction },
-                        { type: "image_url", image_url: { url: dataUrl } },
-                      ],
-                    },
-                  ],
-                  want,
-                ),
+                await runCall([
+                  { role: "system", content: system },
+                  {
+                    role: "user",
+                    content: [
+                      { type: "text", text: userInstruction },
+                      { type: "image_url", image_url: { url: dataUrl } },
+                    ],
+                  },
+                ]),
               );
             } catch (err) {
               if (isPremium && err instanceof AllModelsFailedError) {
@@ -317,13 +315,10 @@ export async function POST(req: NextRequest) {
               avoidClause();
             try {
               pushUnique(
-                await runCall(
-                  [
-                    { role: "system", content: system },
-                    { role: "user", content: user },
-                  ],
-                  want,
-                ),
+                await runCall([
+                  { role: "system", content: system },
+                  { role: "user", content: user },
+                ]),
               );
             } catch (err) {
               if (isPremium && err instanceof AllModelsFailedError) {

--- a/src/app/api/ai/quiz/generate/route.ts
+++ b/src/app/api/ai/quiz/generate/route.ts
@@ -254,15 +254,16 @@ export async function POST(req: NextRequest) {
       };
 
       // Run one call → polish → validate, returning the usable questions.
-      // `want` sizes the output token cap so the JSON array for that many
-      // questions isn't truncated (~170 tokens per MCQ + overhead).
+      // No output token cap (`maxTokens: 0`) — the model returns as many
+      // tokens as it wants, so the JSON array is never truncated mid-way
+      // regardless of how many questions it produces. Runtime is still bounded
+      // by the per-call `deadlineMs` and the route's maxDuration.
       const runCall = async (
         messages: Parameters<typeof chatWithFallback>[0],
-        want: number,
       ): Promise<QuizQuestion[]> => {
         const resp = await chatWithFallback(messages, chain, {
           deadlineMs: remainingBudget(),
-          maxTokens: 400 + want * 180,
+          maxTokens: 0,
         });
         const parsed = normalizeOpenRouterQuiz(resp.content);
         if (!parsed || !parsed.questions?.length) return [];
@@ -307,19 +308,16 @@ export async function POST(req: NextRequest) {
               `questions from it instead of guessing.` + avoidClause();
             try {
               pushUnique(
-                await runCall(
-                  [
-                    { role: "system", content: system },
-                    {
-                      role: "user",
-                      content: [
-                        { type: "text", text: userInstruction },
-                        { type: "image_url", image_url: { url: dataUrl } },
-                      ],
-                    },
-                  ],
-                  want,
-                ),
+                await runCall([
+                  { role: "system", content: system },
+                  {
+                    role: "user",
+                    content: [
+                      { type: "text", text: userInstruction },
+                      { type: "image_url", image_url: { url: dataUrl } },
+                    ],
+                  },
+                ]),
               );
             } catch (err) {
               if (isPremium && err instanceof AllModelsFailedError) {
@@ -358,13 +356,10 @@ export async function POST(req: NextRequest) {
               avoidClause();
             try {
               pushUnique(
-                await runCall(
-                  [
-                    { role: "system", content: system },
-                    { role: "user", content: user },
-                  ],
-                  want,
-                ),
+                await runCall([
+                  { role: "system", content: system },
+                  { role: "user", content: user },
+                ]),
               );
             } catch (err) {
               // Premium errors should surface (we'll refund below); free

--- a/src/lib/ai/openrouter.ts
+++ b/src/lib/ai/openrouter.ts
@@ -118,7 +118,7 @@ async function callModel(
     model: string,
     messages: ChatMessage[],
     signal: AbortSignal,
-    maxTokens: number,
+    maxTokens: number | undefined,
 ): Promise<{ ok: true; result: OpenRouterResult } | { ok: false; status: number; retryable: boolean }> {
     if (!process.env.OPENROUTER_API_KEY) {
         console.error("[openrouter] OPENROUTER_API_KEY is not set");
@@ -140,10 +140,12 @@ async function callModel(
             messages,
             temperature: 0.2, // low → consistent, fewer wasted tokens
             // Caller-controlled output cap. The analyze route wants this small
-            // (single verdict, keep cost down); the quiz/flashcard generators
-            // need it large enough to fit a full JSON ARRAY — a 500-token cap
-            // truncates the array mid-way and silently drops questions/cards.
-            max_tokens: maxTokens,
+            // (single verdict, keep cost down). The quiz/flashcard generators
+            // pass `undefined` here so NO cap is sent — the model returns as
+            // many tokens as it wants, so a long JSON ARRAY is never truncated
+            // mid-way (which used to silently drop questions/cards). The time
+            // budget (deadlineMs / maxDuration) still bounds total runtime.
+            ...(maxTokens != null ? { max_tokens: maxTokens } : {}),
             // NOTE: response_format is intentionally omitted. Several
             // OpenRouter free models 400 on it; the prompt already asks for
             // JSON and parseAnalysis() extracts it defensively.
@@ -186,10 +188,14 @@ export async function chatWithFallback(
     chainOrTier: readonly string[] | Tier = "free",
     opts: { deadlineMs?: number; maxTokens?: number } = {},
 ): Promise<OpenRouterResult> {
-    // Output token cap. Default 500 keeps the analyze route cheap; generators
-    // pass a larger value sized to the requested item count so the JSON array
-    // isn't truncated. Floor at 256, ceil at 8000 to bound cost.
-    const maxTokens = Math.min(8000, Math.max(256, opts.maxTokens ?? 500));
+    // Output token cap. Default 500 keeps the analyze route cheap. Pass
+    // `maxTokens: 0` to send NO cap at all — the model then returns as many
+    // tokens as it wants (used by the quiz/flashcard generators so a long
+    // JSON array is never truncated). Otherwise floor at 256, ceil at 8000.
+    const maxTokens =
+        opts.maxTokens === 0
+            ? undefined
+            : Math.min(8000, Math.max(256, opts.maxTokens ?? 500));
     // Accept either an explicit model chain or a tier (back-compat).
     const chain: readonly string[] = Array.isArray(chainOrTier)
         ? chainOrTier


### PR DESCRIPTION
## What changed

Removed the output token cap on the **quiz** and **flashcard** generators so the model returns as many tokens as it wants.

- `chatWithFallback` now treats `maxTokens: 0` as "no cap" and **omits the `max_tokens` field entirely** from the OpenRouter request. Any other value still clamps to 256–8000; callers that pass nothing keep the default of 500.
- [quiz/generate/route.ts](src/app/api/ai/quiz/generate/route.ts) and [flashcards/generate/route.ts](src/app/api/ai/flashcards/generate/route.ts) now pass `maxTokens: 0`. The now-unused per-call `want` token-sizing param was removed from `runCall`.

## Why

Both generators previously sized `max_tokens` to the requested item count (e.g. `400 + want * 180`). When the model produced a longer JSON array than that estimate, the response was truncated mid-array and the trailing questions/cards were silently dropped — a contributor to the "asked for N, got fewer" behavior. Letting the model emit the full array fixes that.

## Reviewer notes

- **Not a timeout risk:** the per-call `deadlineMs` and each route's `maxDuration: 60` still bound total runtime. Only the output-length ceiling is removed, so this does not reintroduce `FUNCTION_INVOCATION_TIMEOUT`.
- **Left capped on purpose:** answer-analysis (`/api/ai/analyze`, 500 tokens — single verdict, keep it cheap) and Study Companion chat (`/api/ai/study-companion/chat`, 700 tokens — reply pacing).
- Typecheck (`tsc --noEmit`) and ESLint pass on the changed files.
- Unrelated: a 500 on `/api/ai/quiz/generate` was reported separately; it is **not** addressed here (a token cap can't cause a 500 — that's a separate unhandled throw, most likely PDF extraction).
