### PR TITLE
fix: premium credit spend 500 (Unknown error) — RPC signature mismatch

### DIFF
--- a/src/lib/ai/credits.ts
+++ b/src/lib/ai/credits.ts
@@ -14,17 +14,31 @@ export async function getCredits(userId: string): Promise<number> {
 }
 
 /**
- * Atomically spend `amount` credits via the Postgres function. Returns the
- * new balance, or null when the user can't afford the full amount (no
- * partial spend; the row lock makes it safe against double-spend races).
+ * Atomically spend one credit via the Postgres function. Returns the new
+ * balance, or null when the user has no credits (no partial spend; the row
+ * lock makes it safe against double-spend races).
+ *
+ * IMPORTANT: the deployed `spend_ai_credit` takes ONLY `p_user_id` and always
+ * deducts a single credit. We must NOT pass `p_amount` — the (uuid, int)
+ * overload from migration 010 was never applied to prod, so passing it makes
+ * PostgREST fail to resolve the function (PGRST202) and the whole premium
+ * request 500s with "Unknown error". Calling with just `p_user_id` also
+ * resolves correctly against the migration's (uuid, int default 1) version,
+ * so this is safe whether or not the DB is later reconciled (see
+ * migration 011). Premium cost is always 1 today; guard against any future
+ * caller assuming multi-credit spends work here.
  */
 export async function spendCredit(
   userId: string,
   amount = 1,
 ): Promise<number | null> {
+  if (amount !== 1) {
+    throw new Error(
+      `spendCredit: the deployed spend_ai_credit RPC only supports single-credit spends (got amount=${amount}).`,
+    );
+  }
   const { data, error } = await admin.rpc("spend_ai_credit", {
     p_user_id: userId,
-    p_amount: amount,
   });
   if (error) throw error;
   const balance = Number(data);

--- a/supabase/migrations/011_fix_spend_ai_credit.sql
+++ b/supabase/migrations/011_fix_spend_ai_credit.sql
@@ -1,0 +1,46 @@
+-- 011_fix_spend_ai_credit.sql
+--
+-- Production drifted from migration 010: the live database only has the
+-- legacy single-argument `spend_ai_credit(uuid)` function, but 010 defines
+-- `spend_ai_credit(uuid, int default 1)`. The app was calling the two-arg
+-- signature, which PostgREST could not resolve — every premium request
+-- (quiz/flashcard generation, answer analysis, Study Companion chat) failed
+-- with PGRST202 surfaced to the user as a 500 "Unknown error".
+--
+-- This migration reconciles the DB back to 010: it drops the stray single-arg
+-- overload and (re)creates the canonical two-arg version. Idempotent — safe to
+-- run more than once.
+--
+-- NOTE: the application code (src/lib/ai/credits.ts) deliberately calls
+-- `spend_ai_credit` with ONLY p_user_id, which resolves correctly against
+-- this two-arg-with-default function AND against the legacy single-arg one,
+-- so the app keeps working whether or not this migration has been applied.
+
+drop function if exists spend_ai_credit(uuid);
+
+create or replace function spend_ai_credit(p_user_id uuid, p_amount int default 1)
+returns int
+language plpgsql
+security definer
+as $$
+declare
+  new_balance int;
+  cost int := greatest(1, p_amount);
+begin
+  update ai_credit_balances
+    set balance = balance - cost, updated_at = now()
+    where user_id = p_user_id and balance >= cost
+    returning balance into new_balance;
+
+  if new_balance is null then
+    return -1;  -- no row, or insufficient balance
+  end if;
+
+  insert into ai_credit_ledger (user_id, delta, reason)
+    values (p_user_id, -cost, 'spend');
+
+  return new_balance;
+end;
+$$;
+
+revoke all on function spend_ai_credit(uuid, int) from anon, authenticated;


### PR DESCRIPTION
## What changed

Fixes the **500 "Unknown error"** on every premium (credit-spending) request: quiz generation, flashcard generation, answer analysis, and Study Companion chat.

- **[src/lib/ai/credits.ts](src/lib/ai/credits.ts)** — `spendCredit()` now calls the `spend_ai_credit` RPC with **only `p_user_id`** (dropping `p_amount`). Added a guard that throws if a caller ever requests `amount !== 1`.
- **[supabase/migrations/011_fix_spend_ai_credit.sql](supabase/migrations/011_fix_spend_ai_credit.sql)** — reconciles the production DB back to migration `010`: drops the stray single-arg overload and recreates the canonical two-arg `spend_ai_credit(uuid, int default 1)`.

## Why

`spendCredit()` invoked the RPC as `spend_ai_credit(p_user_id, p_amount)`, but **production only has the single-arg `spend_ai_credit(p_user_id)`** — migration `010` (which introduced `p_amount`) was never applied to prod. PostgREST couldn't resolve the two-arg signature and returned `PGRST202`. Because that error is thrown as a plain object (not an `Error`), the route's catch-all reported the generic `"Unknown error"` with a 500.

Root cause was confirmed by calling the RPC directly against prod:
```
message: Could not find the function public.spend_ai_credit(p_amount, p_user_id) in the schema cache
code: PGRST202
hint: Perhaps you meant to call the function public.spend_ai_credit(p_user_id)
```

Calling with only `p_user_id` resolves correctly against **both** the deployed single-arg function **and** the migration's two-arg-with-default version, so the app works whether or not the DB is reconciled. Premium cost is always `1` today, hence the guard.

## Reviewer notes

- **No credits were lost** by the earlier failures — the RPC threw at resolution time, before any deduction.
- **Two ways to fix prod:** (1) merge + deploy this code change, or (2) faster with no redeploy — run migration `011` in the Supabase SQL editor, which creates the two-arg function the currently-deployed code already calls. Doing both is recommended. (Migrations aren't auto-applied; `011` must be run manually.)
- The fix was verified live: a single-arg `spend_ai_credit({ p_user_id })` call returns the new balance correctly (net-zero probe, balance restored).
- Typecheck (`tsc --noEmit`) and ESLint pass.
