### PR TITLE
fix: route premium (Claude) requests to Anthropic API directly

### DIFF
--- a/src/app/api/ai/study-companion/chat/route.ts
+++ b/src/app/api/ai/study-companion/chat/route.ts
@@ -3,7 +3,9 @@ import {
   resolveChain,
   modelTier,
   PREMIUM_CREDIT_COST,
+  PREMIUM_MODEL_CHAIN,
 } from "@/lib/ai/openrouter";
+import { streamClaude } from "@/lib/anthropic";
 import { spendCredit, refundCredit } from "@/lib/ai/credits";
 import { requireUserId } from "@/lib/get-user-id";
 
@@ -241,8 +243,21 @@ export async function POST(req: NextRequest) {
           ...messages,
         ];
 
+        // Premium → stream DIRECTLY from the funded Anthropic API (not the
+        // unfunded OpenRouter account). Free → OpenRouter free-model chain.
+        const deltaSource = isPremium
+          ? streamClaude(allMessages, {
+              // No `temperature` — newer Claude models reject it and 400.
+              model: (requestedModel ?? PREMIUM_MODEL_CHAIN[0]).replace(
+                /^anthropic\//,
+                "",
+              ),
+              maxTokens: 700,
+            })
+          : streamWithFallback(allMessages, chain);
+
         let streamed = false;
-        for await (const delta of streamWithFallback(allMessages, chain)) {
+        for await (const delta of deltaSource) {
           streamed = true;
           controller.enqueue(
             encoder.encode(

--- a/src/lib/ai/openrouter.ts
+++ b/src/lib/ai/openrouter.ts
@@ -104,14 +104,117 @@ export class AllModelsFailedError extends Error {
         const message =
             lastStatus === 401 || lastStatus === 403
                 ? "AI is not configured correctly (auth failed). Please contact support."
-                : lastStatus === 400 || lastStatus === 404
-                  ? "AI request was rejected by every model. The model list may be out of date."
-                  : lastStatus === 429
-                    ? "Free AI quota is exhausted for now. Try again later, or use a Premium credit (Claude) for instant analysis."
-                    : "All AI models are busy right now. Please try again in a minute.";
+                : lastStatus === 402
+                  ? "Premium AI is temporarily unavailable: the OpenRouter account has insufficient credits. Please top it up at openrouter.ai/settings/credits."
+                  : lastStatus === 400 || lastStatus === 404
+                    ? "AI request was rejected by every model. The model list may be out of date."
+                    : lastStatus === 429
+                      ? "Free AI quota is exhausted for now. Try again later, or use a Premium credit (Claude) for instant analysis."
+                      : "All AI models are busy right now. Please try again in a minute.";
         super(message);
         this.name = "AllModelsFailedError";
     }
+}
+
+// ── Direct Anthropic (Claude) API ─────────────────────────────────────────
+// Premium models are paid Claude models. We bill them against the user's
+// OWN funded Anthropic account (ANTHROPIC_API_KEY), NOT OpenRouter — routing
+// Claude through an unfunded OpenRouter account just yields 402s that surface
+// as "all models busy". Anthropic uses a different request shape (top-level
+// `system`, base64 image blocks) and REQUIRES max_tokens, so we translate.
+const ANTHROPIC_ENDPOINT = "https://api.anthropic.com/v1/messages";
+const ANTHROPIC_VERSION = "2023-06-01";
+
+/** True for the premium Claude models that should hit Anthropic directly. */
+function isAnthropicModel(model: string): boolean {
+    return model.startsWith("anthropic/") || model.startsWith("claude");
+}
+
+/** Translate an OpenRouter-style message content into Anthropic's shape. */
+function toAnthropicContent(content: ChatMessage["content"]) {
+    if (typeof content === "string") return content;
+    return content.map((part) => {
+        if (part.type === "text") return { type: "text", text: part.text };
+        // OpenRouter sends images as a data URL; Anthropic wants a base64
+        // image block (or a url source). Parse the data URL when present.
+        const url = part.image_url.url;
+        const m = url.match(/^data:([^;]+);base64,(.*)$/);
+        if (m) {
+            return { type: "image", source: { type: "base64", media_type: m[1], data: m[2] } };
+        }
+        return { type: "image", source: { type: "url", url } };
+    });
+}
+
+async function callAnthropic(
+    model: string,
+    messages: ChatMessage[],
+    signal: AbortSignal,
+    maxTokens: number,
+): Promise<{ ok: true; result: OpenRouterResult } | { ok: false; status: number; retryable: boolean }> {
+    const apiKey = process.env.ANTHROPIC_API_KEY;
+    if (!apiKey) {
+        console.error("[anthropic] ANTHROPIC_API_KEY is not set");
+        return { ok: false, status: 401, retryable: false };
+    }
+    // Strip the OpenRouter "anthropic/" prefix → bare Anthropic model id.
+    const anthropicModel = model.replace(/^anthropic\//, "");
+    const system = messages
+        .filter((m) => m.role === "system")
+        .map((m) => (typeof m.content === "string" ? m.content : ""))
+        .join("\n\n")
+        .trim();
+    const convo = messages
+        .filter((m) => m.role !== "system")
+        .map((m) => ({ role: m.role, content: toAnthropicContent(m.content) }));
+
+    const resp = await fetch(ANTHROPIC_ENDPOINT, {
+        method: "POST",
+        signal,
+        headers: {
+            "Content-Type": "application/json",
+            "x-api-key": apiKey,
+            "anthropic-version": ANTHROPIC_VERSION,
+        },
+        body: JSON.stringify({
+            // NOTE: `temperature` is intentionally omitted — newer Claude
+            // models (e.g. claude-opus-4-7) reject it ("temperature is
+            // deprecated for this model") and 400 the whole request.
+            model: anthropicModel,
+            max_tokens: maxTokens,
+            ...(system ? { system } : {}),
+            messages: convo,
+        }),
+    });
+
+    if (!resp.ok) {
+        const bodyText = await resp.text().catch(() => "");
+        console.error(`[anthropic] ${anthropicModel} → ${resp.status}: ${bodyText.slice(0, 300)}`);
+        if (resp.status === 429) return { ok: false, status: 429, retryable: true };
+        if (resp.status >= 500) return { ok: false, status: resp.status, retryable: true };
+        return { ok: false, status: resp.status, retryable: false };
+    }
+
+    const json = await resp.json();
+    const blocks: Array<{ type: string; text?: string }> = json?.content ?? [];
+    const content = blocks
+        .filter((b) => b.type === "text" && typeof b.text === "string")
+        .map((b) => b.text as string)
+        .join("");
+    if (!content) {
+        console.error(`[anthropic] ${anthropicModel} → empty content`, JSON.stringify(json).slice(0, 300));
+        return { ok: false, status: 502, retryable: true };
+    }
+    return {
+        ok: true,
+        result: {
+            content,
+            model,
+            usage: json?.usage
+                ? { prompt_tokens: json.usage.input_tokens, completion_tokens: json.usage.output_tokens }
+                : undefined,
+        },
+    };
 }
 
 async function callModel(
@@ -120,6 +223,12 @@ async function callModel(
     signal: AbortSignal,
     maxTokens: number | undefined,
 ): Promise<{ ok: true; result: OpenRouterResult } | { ok: false; status: number; retryable: boolean }> {
+    // Premium Claude models go DIRECT to the Anthropic API (funded), bypassing
+    // OpenRouter entirely. Anthropic requires a max_tokens, so default it.
+    if (isAnthropicModel(model)) {
+        return callAnthropic(model, messages, signal, maxTokens ?? 4096);
+    }
+
     if (!process.env.OPENROUTER_API_KEY) {
         console.error("[openrouter] OPENROUTER_API_KEY is not set");
         return { ok: false, status: 401, retryable: false };
@@ -139,12 +248,10 @@ async function callModel(
             model,
             messages,
             temperature: 0.2, // low → consistent, fewer wasted tokens
-            // Caller-controlled output cap. The analyze route wants this small
-            // (single verdict, keep cost down). The quiz/flashcard generators
-            // pass `undefined` here so NO cap is sent — the model returns as
-            // many tokens as it wants, so a long JSON ARRAY is never truncated
-            // mid-way (which used to silently drop questions/cards). The time
-            // budget (deadlineMs / maxDuration) still bounds total runtime.
+            // Caller-controlled output cap (always a number here). The analyze
+            // route keeps it small; the generators pass a generous bound so a
+            // long JSON array isn't truncated. We never omit it — OpenRouter
+            // would otherwise assume the model max and 402 paid requests.
             ...(maxTokens != null ? { max_tokens: maxTokens } : {}),
             // NOTE: response_format is intentionally omitted. Several
             // OpenRouter free models 400 on it; the prompt already asks for
@@ -189,12 +296,17 @@ export async function chatWithFallback(
     opts: { deadlineMs?: number; maxTokens?: number } = {},
 ): Promise<OpenRouterResult> {
     // Output token cap. Default 500 keeps the analyze route cheap. Pass
-    // `maxTokens: 0` to send NO cap at all — the model then returns as many
-    // tokens as it wants (used by the quiz/flashcard generators so a long
-    // JSON array is never truncated). Otherwise floor at 256, ceil at 8000.
+    // `maxTokens: 0` for "uncapped" — we send a generous bound (16000) rather
+    // than omitting the field, because (a) Anthropic REQUIRES max_tokens and
+    // (b) omitting it makes OpenRouter assume the model max (65536) and reject
+    // paid requests up front with a 402. Anthropic bills only the tokens it
+    // actually emits, so a high ceiling never costs more than the real output.
+    // The quiz/flashcard generators use this so a long JSON array isn't
+    // truncated. Otherwise floor at 256, ceil at 8000.
+    const UNCAPPED_MAX_TOKENS = 16000;
     const maxTokens =
         opts.maxTokens === 0
-            ? undefined
+            ? UNCAPPED_MAX_TOKENS
             : Math.min(8000, Math.max(256, opts.maxTokens ?? 500));
     // Accept either an explicit model chain or a tier (back-compat).
     const chain: readonly string[] = Array.isArray(chainOrTier)


### PR DESCRIPTION
## What changed

Premium AI (quiz/flashcard generation, answer analysis, Study Companion chat) now calls the **Anthropic API directly** instead of routing Claude through OpenRouter.

- **[src/lib/ai/openrouter.ts](src/lib/ai/openrouter.ts)**
  - `callModel` detects Anthropic models (`anthropic/*`) and routes them to a new `callAnthropic` that hits `api.anthropic.com` with `ANTHROPIC_API_KEY`. It translates the request shape (system → top-level `system`, OpenRouter `image_url` data URLs → Anthropic base64 image blocks) and reads Claude's `content` blocks. Free models still go through OpenRouter.
  - Dropped `temperature` from Anthropic requests — `claude-opus-4-7` **rejects it** (`"temperature is deprecated for this model"`) and 400s the whole call.
  - Fixed `max_tokens`: the "uncapped" path (`maxTokens: 0`) now sends a generous bound (16000) instead of omitting the field. Omitting it broke Anthropic (which *requires* `max_tokens`) and made OpenRouter pre-authorize the model max (65536) → 402 on paid requests. Anthropic bills only actual output tokens, so the high ceiling is free headroom.
  - Added a clear **402** error message instead of the misleading "All AI models are busy."
- **[src/app/api/ai/study-companion/chat/route.ts](src/app/api/ai/study-companion/chat/route.ts)**
  - Premium replies stream directly from Anthropic via `streamClaude` (also without `temperature`). Free chat stays on the OpenRouter free-model chain.

## Why

Every premium request was sent through OpenRouter, but that account is on the **unfunded free tier**. Paid Claude requests returned `402` ("insufficient credits / fewer max_tokens"), which is non-retryable; with a single-model premium chain it collapsed into the generic "All AI models are busy." Meanwhile the project already had a **funded** direct Anthropic key that was only used for a JSON-extraction helper.

Diagnosis was confirmed against the live providers:
- `claude-opus-4-7` via `api.anthropic.com` → **200 OK** (funded).
- Same model via OpenRouter → **402** (unfunded, `is_free_tier: true`).

## Reviewer notes

- **Production requirement:** `ANTHROPIC_API_KEY` must be set in the Vercel environment. It's present locally; without it premium now fails with "AI is not configured correctly (auth failed)." Free models are unaffected.
- Verified end-to-end: a quiz-generation prompt to `claude-opus-4-7` returned 200 with valid JSON (3 questions, ~4s, 353 output tokens).
- Free-tier behavior is unchanged (still OpenRouter `:free` models).
- Typecheck (`tsc --noEmit`) and ESLint pass.
