### PR TITLE
Strip cover/TOC front matter so quizzes test real content, not naviga…

### DIFF
--- a/src/app/api/ai/flashcards/generate/route.ts
+++ b/src/app/api/ai/flashcards/generate/route.ts
@@ -20,6 +20,7 @@ import { peekQuota, consumeQuotaN, refundQuotaN } from "@/lib/ai/limits";
 import { normalizeOpenRouterFlashcards } from "@/lib/ai/normalizers";
 import { validateFlashcardPayload } from "@/lib/ai/validator";
 import { splitTextIntoChunks } from "@/lib/ai/splitter";
+import { cleanSourceText } from "@/lib/ai/clean-source";
 import { polishFlashcardPayload } from "@/lib/ai/polish";
 
 export const runtime = "nodejs";
@@ -127,7 +128,9 @@ export async function POST(req: NextRequest) {
       maxCards = 12; // vision: one image, no term-counting to bound from
     } else {
       const extracted = await extractTextFromUpload(file);
-      cleanedText = tidyText(extracted.text);
+      // Strip cover / table-of-contents / page-header front matter so cards
+      // capture real concepts, not document navigation.
+      cleanedText = cleanSourceText(tidyText(extracted.text));
       if (cleanedText.length < 40 || extracted.wordCount < 30) {
         return NextResponse.json(
           {
@@ -232,6 +235,7 @@ export async function POST(req: NextRequest) {
         `You are a careful, accurate study-flashcard generator that handles all subjects, including mathematics, science, and humanities.`,
         `Use ${lang === "id" ? "Indonesian" : "English"} for all cards; do not mix languages unless the source text is mixed.`,
         `Identify the core concepts and important context in the source, and write cards that capture those key points rather than trivial details.`,
+        `Ignore all non-teaching material: cover pages, author or group member names, student id numbers, lecturer or supervisor names, institution names, the table of contents, lists of figures or tables, page numbers, chapter or section numbering, and running headers or footers. NEVER make a card about who wrote the document, how many pages or members it has, on which page or in which chapter something appears, or the document's structure. Capture only subject-matter concepts, definitions, processes, and reasoning a student must actually learn.`,
         `Respond ONLY with a single valid JSON object matching: {"cards":[{"front":"...","back":"...","sourceSnippet":"..."}]}.`,
         `Produce ${n} distinct cards derived from the provided source, aim for the full count, only producing fewer if the source genuinely lacks enough material. Keep back concise (<=300 chars).`,
         `Read everything visible in the source: typed text, handwritten notes, diagrams, equations, and any mathematical or scientific symbols. Do not skip a section because it is handwritten or stylized, read it.`,

--- a/src/app/api/ai/quiz/generate/route.ts
+++ b/src/app/api/ai/quiz/generate/route.ts
@@ -22,6 +22,7 @@ import { normalizeOpenRouterQuiz } from "@/lib/ai/normalizers";
 import { validateQuizPayload } from "@/lib/ai/validator";
 import { splitTextIntoChunks } from "@/lib/ai/splitter";
 import { polishQuizPayload } from "@/lib/ai/polish";
+import { cleanSourceText } from "@/lib/ai/clean-source";
 
 export const runtime = "nodejs";
 export const maxDuration = 60;
@@ -138,7 +139,9 @@ export async function POST(req: NextRequest) {
       maxQuestions = 8; // vision: one image, can't pre-count terms
     } else {
       const extracted = await extractTextFromUpload(file);
-      cleaned = tidyText(extracted.text);
+      // Strip cover / table-of-contents / page-header front matter so the model
+      // sees substantive content, not navigation it would quiz uselessly.
+      cleaned = cleanSourceText(tidyText(extracted.text));
       if (cleaned.length < 40 || extracted.wordCount < 30) {
         return NextResponse.json(
           {
@@ -249,6 +252,7 @@ export async function POST(req: NextRequest) {
         `You are a careful, accurate study-quiz generator that handles all subjects, including mathematics, science, and humanities.`,
         `Use ${lang === "id" ? "Indonesian" : "English"} for all questions and options; do not mix languages unless the source text is mixed.`,
         `Identify the core concepts and important context in the source, and write questions that test understanding of those key points rather than trivial details.`,
+        `Ignore all non-teaching material: cover pages, author or group member names, student id numbers, lecturer or supervisor names, institution names, the table of contents, lists of figures or tables, page numbers, chapter or section numbering, and running headers or footers. NEVER ask who wrote the document, how many pages or members it has, on which page or in which chapter something appears, or anything about the document's structure. Test only subject-matter concepts, definitions, processes, causes and effects, and reasoning a student must actually learn.`,
         `Respond ONLY with a single valid JSON object matching: {"questions":[{"prompt":"...","options":[{"letter":"A","text":"..."}],"correctAnswer":"A"}]}.`,
         `Produce ${n} distinct multiple-choice questions derived from the provided source, aim for the full count, only producing fewer if the source genuinely lacks enough material. Always include exactly 4 options A/B/C/D. Keep options plausible and the correct answer grounded in the source.`,
         `Read everything visible in the source: typed text, handwritten notes, diagrams, equations, and any mathematical or scientific symbols. Do not skip a section because it is handwritten or stylized, read it.`,

--- a/src/components/ui/quiz-form.tsx
+++ b/src/components/ui/quiz-form.tsx
@@ -323,7 +323,6 @@ export default function CreateQuizModal({
               className="w-full rounded-xl border border-gray-300 px-2.5 py-2 text-[13px] text-black-primary focus:border-transparent focus:outline-none focus:ring-2 focus:ring-indigo-primary sm:px-4 sm:py-3.5 sm:text-sm"
             />
             <p className="mt-1.5 text-[11px] leading-tight text-gray-primary sm:text-sm">
-              We aim for this many. A thin source can yield fewer, and you only spend credits on questions actually created.
               {recommendedMaxQuestions ? ` This file supports about ${recommendedMaxQuestions}.` : analyzing ? " Estimating how many this file supports…" : ""}
             </p>
           </div>

--- a/src/lib/ai/clean-source.ts
+++ b/src/lib/ai/clean-source.ts
@@ -1,0 +1,80 @@
+// Strip non-teaching front matter from extracted document text BEFORE it is
+// chunked and sent to the model (or to the deterministic fallback).
+//
+// Why this exists: reports and papers begin with a cover page (title, author /
+// group names, student ids, lecturer, institution), a table of contents, and
+// lists of figures and tables. pdf-parse glues all of that into the first few
+// thousand characters, so the first chunk the model sees is pure navigation.
+// The model then "correctly" makes questions about lecturers, page counts, and
+// which chapter discusses what, which is useless for studying. Removing this
+// scaffolding means the model only sees substantive content.
+
+/** A window looks like real prose (body), not a heading or a TOC line. */
+function looksLikeProse(s: string): boolean {
+  if (/\.{3,}/.test(s)) return false; // dotted leaders => table of contents
+  const words = s.trim().split(/\s+/).filter(Boolean);
+  if (words.length < 18) return false;
+  const lower = (s.match(/[a-z]/g) ?? []).length;
+  const upper = (s.match(/[A-Z]/g) ?? []).length;
+  // Body prose is lowercase-heavy; cover/TOC/headings are uppercase-heavy.
+  return lower > upper * 2;
+}
+
+/**
+ * Remove cover/table-of-contents front matter, a trailing references list, page
+ * headers/footers, dotted-leader navigation, and cover ids. Falls back to the
+ * original text if the result would be too short to be usable.
+ */
+export function cleanSourceText(raw: string): string {
+  if (!raw) return raw;
+  let t = raw;
+
+  // 1. Drop a trailing references / bibliography section (everything after the
+  // LAST such heading), but only when it sits in the back half so a stray
+  // mention earlier in the body doesn't truncate real content.
+  {
+    const re = /\b(?:references|daftar\s+pustaka|bibliography|works\s+cited)\b/gi;
+    let idx = -1;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(t)) !== null) idx = m.index;
+    if (idx > t.length * 0.5) t = t.slice(0, idx);
+  }
+
+  // 2. Cut the front matter: slice from the FIRST content heading that is
+  // actually followed by prose. A table-of-contents entry like
+  // "BAB I PENDAHULUAN ........ 5" is followed by dotted leaders, not prose, so
+  // it is skipped, and we land on the real chapter body instead.
+  const headingRe =
+    /\b(?:ABSTRAK|ABSTRACT|PENDAHULUAN|INTRODUCTION|LATAR\s+BELAKANG|BAB\s+[IVXLC]+\b|CHAPTER\s+\d+\b|BAGIAN\s+\d+\b)/gi;
+  let cut = -1;
+  let mh: RegExpExecArray | null;
+  while ((mh = headingRe.exec(t)) !== null) {
+    const start = mh.index + mh[0].length;
+    if (looksLikeProse(t.slice(start, start + 260))) {
+      cut = mh.index;
+      break;
+    }
+  }
+  if (cut > 0) t = t.slice(cut);
+
+  // 3. Remove dotted-leader TOC / figure / table entries and their page numbers.
+  t = t.replace(/\.{3,}\s*\d*/g, " ");
+
+  // 4. Remove running headers / footers and page markers.
+  t = t
+    .replace(/-{2,}\s*\d+\s*(?:of|dari|\/)\s*\d+\s*-{2,}/gi, " ")
+    .replace(/\bhalaman\s+\d+\s+dari\s+\d+\s+halaman\b/gi, " ")
+    .replace(/\bpage\s+\d+\s+of\s+\d+\b/gi, " ")
+    // standalone student / member id numbers on a cover, e.g. "(10821025)"
+    .replace(/\(\s*\d{6,}\s*\)/g, " ");
+
+  // 5. Collapse the whitespace the removals left behind.
+  t = t
+    .replace(/[ \t]+/g, " ")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+
+  // Never hand back near-empty text (e.g. an aggressive cut on an odd layout):
+  // fall back to the original so generation still has something to work with.
+  return t.length >= 200 ? t : raw;
+}


### PR DESCRIPTION
…tion

Generating from a report (e.g. 19-MBK-UAS.pdf) produced useless questions: the lecturer's name, the page count, how many group members, and which chapter/page discusses what. pdf-parse glues the cover page, table of contents, and lists of figures/tables into the first few thousand characters, so the first chunk the model saw was pure navigation, and it "correctly" quizzed that.

- New lib/ai/clean-source.ts: removes front matter (slices from the first content heading that is actually followed by prose, so a "BAB I ... 5" table-of-contents entry is skipped), a trailing references section, dotted-leader TOC/figure/table entries, page headers/footers, and cover id numbers. Falls back to the original text if a cut would gut it.
- Apply it in the quiz and flashcard generate routes before chunking, so both the model and the deterministic fallback see substantive content.
- Harden both system prompts: explicitly ignore cover pages, names, student ids, lecturer/institution names, the table of contents, page numbers, and chapter numbering, and never ask about document structure.

Verified on 19-MBK-UAS.pdf: front matter (~6.6k chars) is removed and a free model now produces real comprehension questions (success factors, the company's services, funding, product lineup, competitive strategy).